### PR TITLE
Reconfigure env variable for npm start to work fine on npm start

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -21,7 +21,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This PR 

Fixed issue coming when running npm start to start optio front end service. This seems to be an issue with node version so reconfiguring environment variable helped to fix this. Reference taken from [here](https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os)